### PR TITLE
[Mission-1-3-yuta]メッセージ編集機能

### DIFF
--- a/yuta/assets/js/app.js
+++ b/yuta/assets/js/app.js
@@ -44,7 +44,7 @@
         this.editedBody = null
       },
       doneEdit() {
-        this.updateMessage({id: this.id, body: this.editedBody})
+        this.updateMessage({id: this.id, body: this.editedBody, username: this.username})
           .then(response => {
             this.cancelEdit()
           })

--- a/yuta/controller/message.go
+++ b/yuta/controller/message.go
@@ -95,11 +95,34 @@ func (m *Message) Create(c *gin.Context) {
 	})
 }
 
-// UpdateByID は...
 func (m *Message) UpdateByID(c *gin.Context) {
-	// 1-3. メッセージを編集しよう
-	// ...
-	c.JSON(http.StatusCreated, gin.H{})
+	var msg model.Message
+
+	if c.Request.ContentLength == 0 {
+		resp := httputil.NewErrorResponse(errors.New("body is missing"))
+		c.JSON(http.StatusBadRequest, resp)
+		return
+	}
+
+	if err := c.BindJSON(&msg); err != nil {
+		resp := httputil.NewErrorResponse(err)
+		c.JSON(http.StatusInternalServerError, resp)
+		return
+	}
+
+	updated, err := msg.Update(m.DB)
+	if err != nil {
+		resp := httputil.NewErrorResponse(err)
+		c.JSON(http.StatusInternalServerError, resp)
+		return
+	}
+
+	m.Stream <- updated
+
+	c.JSON(http.StatusCreated, gin.H{
+		"result": updated,
+		"error":  nil,
+	})
 }
 
 // DeleteByID は...

--- a/yuta/model/message.go
+++ b/yuta/model/message.go
@@ -41,7 +41,7 @@ func MessagesAll(db *sql.DB) ([]*Message, error) {
 func MessageByID(db *sql.DB, id string) (*Message, error) {
 	m := &Message{}
 
-	if err := db.QueryRow(`select id, body, message from message where id = ?`, id).Scan(&m.ID, &m.Body, &m.UserName); err != nil {
+	if err := db.QueryRow(`select id, body, username from message where id = ?`, id).Scan(&m.ID, &m.Body, &m.UserName); err != nil {
 		return nil, err
 	}
 
@@ -68,7 +68,26 @@ func (m *Message) Insert(db *sql.DB) (*Message, error) {
 }
 
 // 1-3. メッセージを編集しよう
-// ...
+func (m *Message) Update(db *sql.DB) (*Message, error) {
+	res, err := db.Exec(`update message set body = ? where id = ?`, m.Body, m.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	//if id != m.ID {
+	//	return nil, errors.New("id did not match")
+	//}
+
+	return &Message{
+		ID:       id,
+		Body:     m.Body,
+		UserName: m.UserName,
+	}, nil
+}
 
 // 1-4. メッセージを削除しよう
 // ...


### PR DESCRIPTION
bug:
  メッセージ編集後にユーザー名も上書きされ、空白になる
  reloadすると直る

**修正済み**
